### PR TITLE
fix: Replace `node` with `electron-main`

### DIFF
--- a/template/build/webpack.conf.js
+++ b/template/build/webpack.conf.js
@@ -19,7 +19,7 @@ module.exports = {
   entry: {
     app: './src/main.js'
   },
-  target: 'node',
+  target: 'electron-main',
   externals: config.externals,
   output: {
     filename: 'electron.js',


### PR DESCRIPTION
Replace `target: 'node'` with `target: 'electron-main'` in `webpack.conf.js`

Fix #5